### PR TITLE
feat: add resources carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "react-i18next": "^11.14.2",
     "react-scripts": "5.0.1",
     "react-scroll": "^1.9.0",
+    "react-slick": "^0.29.0",
     "react-waypoint": "^10.3.0",
     "reactstrap": "^9.2.2",
     "sass": "^1.77.8",
+    "slick-carousel": "^1.8.1",
     "typescript": "4.9.5"
   },
   "resolutions": {

--- a/src/components/Ressources/ressources.scss
+++ b/src/components/Ressources/ressources.scss
@@ -13,9 +13,21 @@
   align-items: center;
 }
 
-ul {
-  list-style-type: square;
+.ressources-slider {
+  .slick-slide {
+    padding: 0 10px;
+  }
+  .slick-list {
+    margin: 0 -10px;
+  }
+}
+
+.resource-card {
+  background-color: #111144;
   color: white;
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/components/Ressources/ressources.tsx
+++ b/src/components/Ressources/ressources.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import Slider from 'react-slick';
+import 'slick-carousel/slick/slick-theme.css';
 import ContainerHeading from '../common/container-heading';
 import './ressources.scss';
 
@@ -13,21 +15,27 @@ const Ressources = () => {
   const ressourcesLinks: Link[] = t('Ressources.links', {
     returnObjects: true,
   });
+  const settings = {
+    arrows: false,
+    dots: false,
+    infinite: false,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
   return (
     <div className="ressources">
       <ContainerHeading title="Ressources" />
       <div>
         <p className="ressources-text">{t('Ressources.text')}</p>
-        <ul>
+        <Slider {...settings} className="ressources-slider">
           {ressourcesLinks.map((item, index) => (
-            <li key={index}>
-              <p className="ressources-text">
-                {' '}
-                <a href={item.link}>{item.link}</a> ({item.helperText})
-              </p>
-            </li>
+            <div key={index}>
+              <a href={item.link} target="_blank" rel="noopener noreferrer">
+                <div className="resource-card">{item.helperText}</div>
+              </a>
+            </div>
           ))}
-        </ul>
+        </Slider>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add react-slick carousel dependencies
- display resources as slider cards linking to hidden URLs
- style carousel and resource cards for horizontal scrolling

## Testing
- `npm run lint` *(fails: max-line-length and comment-format in unrelated files)*
- `CI=true npm test` *(fails: Cannot find module 'react-slick')*

------
https://chatgpt.com/codex/tasks/task_e_68bc83ce7ac083208be592f8784fb23f