### PR TITLE
feat: add schedule coming soon overlay

### DIFF
--- a/src/components/schedule/schedule.scss
+++ b/src/components/schedule/schedule.scss
@@ -5,6 +5,7 @@
     font-family: 'Segoe UI';
     min-height: 100vh;
     padding: 5%;
+    position: relative;
     h5 {
         text-align: center;
     }
@@ -28,8 +29,9 @@
         margin: auto;
         .container {
             background-color: $primary;
-        }
-    }
+}
+}
+
     .event {
         border-top: 1px solid white;
         font-size: 1.5vw;
@@ -39,6 +41,21 @@
     }
     .nav-item.active {
         background-color: $secondary;
+    }
+    .schedule-overlay {
+        align-items: center;
+        background-color: rgba(0, 0, 0, 0.6);
+        display: flex;
+        font-size: 5vw;
+        font-weight: bold;
+        height: 100%;
+        justify-content: center;
+        left: 0;
+        position: absolute;
+        text-align: center;
+        top: 0;
+        width: 100%;
+        z-index: 1000;
     }
 }
 

--- a/src/components/schedule/schedule.tsx
+++ b/src/components/schedule/schedule.tsx
@@ -37,6 +37,7 @@ const Schedule: FunctionComponent<ScheduleProps> = ({
 
     return (
         <div className="schedule">
+            <div className="schedule-overlay">{t('Schedule.comingSoon')}</div>
             <ContainerHeading title={t('Schedule.title')}/>
             <h5>{t('Schedule.warning')}</h5>
             <Nav tabs={true}>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -69,6 +69,7 @@
   "Schedule.title": "Schedule",
   "Schedule.day": "Day",
   "Schedule.warning": "All times are in EST.",
+  "Schedule.comingSoon": "Coming soon",
   "Partners.sponsor": "Sponsor Us",
   "Footer.newsletter": "Sign up to our newsletter!",
   "Footer.flaticon": "Flaticon icon authors",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -69,6 +69,7 @@
   "Schedule.title": "Horaire",
   "Schedule.day": "Jour",
   "Schedule.warning": "Toutes les heures sont présentés en EST.",
+  "Schedule.comingSoon": "À venir",
   "Partners.sponsor": "Commanditez-nous!",
   "Footer.newsletter": "Inscris-toi à notre infolettre!",
   "Footer.flaticon": "Auteurs des icones Flaticon",


### PR DESCRIPTION
## Summary
- add Schedule.comingSoon translation keys
- show coming soon overlay on schedule section
- style overlay to cover schedule content

## Testing
- `npm test --silent`
- `npm run lint` *(fails: max-line-length, comment-format)*

------
https://chatgpt.com/codex/tasks/task_e_68bc83cbbd948320a10afdcb72e709f1