### PR TITLE
Add sponsors coming soon overlay

### DIFF
--- a/src/components/landing-hero-page/landing-hero-page.tsx
+++ b/src/components/landing-hero-page/landing-hero-page.tsx
@@ -5,6 +5,9 @@ import { Link } from 'react-scroll';
 import { Col, Row } from 'reactstrap';
 import './landing-hero-page.scss';
 
+const REGISTRATION_LINK =
+  'https://docs.google.com/forms/d/e/1FAIpQLSctJZEYjx8oTROyygyeGTppd8saPMvLELxliPYXlRYYM07z-w/viewform?usp=sf_link';
+
 const LandingHeroPage: React.FC = () => {
   const { t } = useTranslation();
   const [showParticles, setShowParticles] = useState(false);
@@ -53,13 +56,15 @@ const LandingHeroPage: React.FC = () => {
             </h1>
             <p className="subtitle">{t('LandingHeroPage.subtitle')}</p>
             <p className="subtitle"> {t('LandingHeroPage.when')} </p>
-              <button className="register">
-              <a href="https://docs.google.com/forms/d/e/1FAIpQLSctJZEYjx8oTROyygyeGTppd8saPMvLELxliPYXlRYYM07z-w/viewform?usp=sf_link" target="_blank" rel="noopener noreferrer">
-                {' '}
-                {t('LandingHeroPage.register')}{' '}
-      </a>
-
-              </button>
+            <button className="register">
+              <a
+                href={REGISTRATION_LINK}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('LandingHeroPage.register')}
+              </a>
+            </button>
           </Col>
           <Col
             sm={{ order: 'first' }}

--- a/src/components/sponsors/sponsors-data.tsx
+++ b/src/components/sponsors/sponsors-data.tsx
@@ -1,4 +1,4 @@
-//import AECSP from './img/AECSP.svg';
+// import AECSP from './img/AECSP.svg';
 import CN from './img/CN.png';
 import COVEO from './img/coveo.png';
 import DRUIDE from './img/druide.png';

--- a/src/components/sponsors/sponsors.scss
+++ b/src/components/sponsors/sponsors.scss
@@ -17,10 +17,26 @@
     .partners-logos-container {
         padding-top: 10px;
         width: 90%;
+        position: relative;
     }
     
     .center-logos {
         padding-bottom: 20px;
+    }
+
+    .partners-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.8);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 2vw;
+        color: white;
+        z-index: 1;
     }
     
     .sponsor-us-btn {

--- a/src/components/sponsors/sponsors.tsx
+++ b/src/components/sponsors/sponsors.tsx
@@ -29,6 +29,8 @@ const generateLogos = (xs: string, md: string, array: Sponsor[]) => {
 
 const Partners: FunctionComponent = () => {
     const { t } = useTranslation();
+    const showSponsors = false;
+
     return (
         <div className="partners-section" id="partners">
             <ContainerHeading title={t('Partners.title')}/>
@@ -38,6 +40,11 @@ const Partners: FunctionComponent = () => {
                     {generateLogos('2', '3', GOLD)}
                     {generateLogos('3', '4', SILVER)}
                     {generateLogos('4', '5', BRONZE)}
+                    {!showSponsors && (
+                        <div className="partners-overlay">
+                            {t('Partners.comingSoon')}
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -70,6 +70,7 @@
   "Schedule.day": "Day",
   "Schedule.warning": "All times are in EST.",
   "Partners.sponsor": "Sponsor Us",
+  "Partners.comingSoon": "Coming soon",
   "Footer.newsletter": "Sign up to our newsletter!",
   "Footer.flaticon": "Flaticon icon authors",
   "Ressources.text": "If you want to start learning how to use Python and create machine learning models, here are some resources to help you get started!",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -70,6 +70,7 @@
   "Schedule.day": "Jour",
   "Schedule.warning": "Toutes les heures sont présentés en EST.",
   "Partners.sponsor": "Commanditez-nous!",
+  "Partners.comingSoon": "À venir",
   "Footer.newsletter": "Inscris-toi à notre infolettre!",
   "Footer.flaticon": "Auteurs des icones Flaticon",
   "Ressources.text": "Si vous voulez commencer à apprendre à utiliser Python et à créer des modèles d'apprentissage automatique, voici quelques ressources pour vous aider à démarrer!",


### PR DESCRIPTION
## Summary
- add `Partners.comingSoon` translations in English and French
- overlay sponsors section with localized "Coming soon" message
- style sponsors overlay and minor lint cleanups

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc83cd572c8320acf5473a55185c3d