### PR TITLE
Load slick carousel base styles in resources slider

### DIFF
--- a/src/components/Ressources/ressources.tsx
+++ b/src/components/Ressources/ressources.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Slider from 'react-slick';
+import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import ContainerHeading from '../common/container-heading';
 import './ressources.scss';


### PR DESCRIPTION
## Summary
- add slick carousel base stylesheet to resources component

## Testing
- `yarn install` *(fails: RequestError: Bad response: 403)*
- `yarn start` *(fails: package doesn't seem to be present in lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8bedf9048320b75bef67ee0542d6